### PR TITLE
Update README for Japanese MT-Bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Japanese MT-Bench
+
+This repo provides Japanese MT-Bench questions and prompts to evaluate your models with LLM-as-a-judge.
+
+For more details, see the following:
+
+- [fastchat/llm_judge/data/japanese_mt_bench](https://github.com/Stability-AI/FastChat/tree/jp-stable/fastchat/llm_judge/data/japanese_mt_bench), which contains Japanese MT-Bench questions, model answers, and judgements
+- [fastchat/llm_judge/README.md](https://github.com/Stability-AI/FastChat/blob/jp-stable/fastchat/llm_judge/README.md) for how to generate model answers and judgements
+
 # FastChat
 | [**Demo**](https://chat.lmsys.org/) | [**Chatbot Arena**](https://arena.lmsys.org) | [**Discord**](https://discord.gg/HSWAKCrnFx) | [**Twitter**](https://twitter.com/lmsysorg) |
 


### PR DESCRIPTION
As per title, this PR updates the README to add information about the Japanese MT-Bench.

I thought about adding a README.md to the directory https://github.com/Stability-AI/FastChat/tree/jp-stable/fastchat/llm_judge/data/japanese_mt_bench and writing about how to generate the files in that directory, but that information is pretty much already contained in https://github.com/Stability-AI/FastChat/blob/jp-stable/fastchat/llm_judge/README.md and is a bit redundant so I simply added pointers to those information in the root README.md.
If there's any other good ideas (e.g. whether we should add a README.md under `fastchat/llm_judge/data/japanese_mt_bench` and if so, what kind of information we should write there), please feel free to let me know. Thanks!